### PR TITLE
add python package python-engineio 3x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy
 matplotlib
 tensorflow==2.17.1
 keras
-python-socketio
 Flask
-Eventlet
+python-socketio==4.6.1
+python-engineio==3.13.2
+eventlet==0.30.2


### PR DESCRIPTION
The new modifications were made on the requirement.txt file. Udacity requires the python-engineio==3.13.2, python-socketio==4.6.1 and eventlet==0.30.2 for the communication between the server and the client simulator.
